### PR TITLE
fix the "Failed to save design" error

### DIFF
--- a/src/pages/DesignFormPage.tsx
+++ b/src/pages/DesignFormPage.tsx
@@ -132,17 +132,21 @@ const DesignFormPage = () => {
         return true; // Indicate success to prevent re-triggering
       }
 
-      const imageUrls = results
-        .filter(r => r && r.imageUrls)
-        .flatMap((result) => result.imageUrls);
+      const validResults = results.filter(r => r && r.imageUrls && r.prompt);
 
-      if (imageUrls.length === 0) {
-        throw new Error("All image generation models failed. Please try again later.");
+      if (validResults.length === 0) {
+        throw new Error("All image generation models failed or returned invalid data. Please try again later.");
       }
 
-      // 3. Navigate to the results page.
+      const imageUrls = validResults.flatMap((result) => result.imageUrls);
+      const prompt = validResults[0].prompt; // Get prompt from the first valid result
+
+      // 3. Navigate to the results page with images and the prompt.
       navigate("/results", {
-        state: { generatedImages: imageUrls },
+        state: { 
+          generatedImages: imageUrls,
+          prompt: prompt 
+        },
       });
 
       return true;


### PR DESCRIPTION
a summary of the fix:

   1. Backend (`/api/generate`): The endpoint now correctly returns the generated prompt alongside the imageUrls.
   2. Frontend (`DesignFormPage.tsx`): This page now extracts the prompt from the API response and passes it to the ResultsPage upon navigation.
   3. Frontend (`ResultsPage.tsx`): This page was already set up to receive the prompt and use it when saving a design, so no changes were needed here.